### PR TITLE
Add missing base url option in command inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,4 +63,5 @@ runs:
     - --copy-latest=${{ inputs.copyLatest }}
     - --ignore-missing-results=${{ inputs.ignoreMissingResults }}
     - --color=${{ inputs.color }}
+    - --base-url=${{ inputs.baseUrl }}
     - ${{ inputs.storageType }}


### PR DESCRIPTION
Fix base-url option not passed to report publisher.

Fixes https://github.com/andrcuns/allure-publish-action/issues/18